### PR TITLE
ADHOC fix (download-timeout): Increase the timeout for downloading n9…

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,7 @@
     dest: "{{ magento_users_install_to_path }}/{{ magento_users_n98mrun_binary_name }}"
     mode: 0755
     owner: "{{ magento_users_owner }}"
+    timeout: 300
 
 - name: get list of existing active users
   shell: "{{ magento_users_n98mrun_binary_name }} admin:user:list --format=\"csv\" | grep -e \"^[0-9]\" | awk -F',' '{print $2}'"


### PR DESCRIPTION
…8-magerun binary.

Using that role caused the provisioning of a machine to break.
As connection timeout out.
Current timeout is default and equal to 10 seconds.
This commit increases the timeout to 5 minutes.